### PR TITLE
Addition of 404 page 

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,7 +4,7 @@
 
   <!-- General metadata -->
   <meta charset="UTF-8" />
-  <title>{% if page.audience == "homepage" %}{{site.title}} | {{site.sub_title}}{% else %}{{page.title}} | {{site.title}}{% endif %}</title>
+  <title>{% if page.audience == "homepage" %}{{site.title}} | {{site.sub_title}} {% if paginator.page > 1 %}| Page {{paginator.page}}{% endif %}{% else %}{{page.title}} | {{site.title}}{% endif %}</title>
 
   <!-- Stylesheets -->  
   <link rel="stylesheet" type="text/css" media="all" href="{{site.baseurl}}/css/style.css" />
@@ -45,99 +45,97 @@
     </div><!-- #container -->
 
 
-<!-- Siderail -->
-<div id="primary" class="widget-area" role="complementary">
-  <ul class="xoxo">
+    {% unless page.audience == "404" %}
+    <!-- Siderail -->
+    <div id="primary" class="widget-area" role="complementary">
+      <ul class="xoxo">
 
-    <!-- Recent Posts -->
-    <li id="recent-posts-2" class="widget-container widget_recent_entries">
-      <h3 class="widget-title">Recent Posts</h3>
-      <ul>
-      {% for post in site.posts limit:5 %}  
-        <li><a href="{{ site.baseurl }}{{ post.url }}">{{ post.breadcrumb }}</a></li>  
-      {% endfor %} 
-      </ul>
-    </li>
+        <!-- Recent Posts -->
+        <li id="recent-posts-2" class="widget-container widget_recent_entries">
+          <h3 class="widget-title">Recent Posts</h3>
+          <ul>
+          {% for post in site.posts limit:5 %}  
+            <li><a href="{{ site.baseurl }}{{ post.url }}">{{ post.breadcrumb }}</a></li>  
+          {% endfor %} 
+          </ul>
+        </li>
 
-    <!-- Recent Comments -->
-    <li id="recent-comments-2" class="widget-container widget_recent_comments">
-      <h3 class="widget-title">Recent Comments</h3>
-      <ul id="recentcomments">
+        <!-- Recent Comments -->
+        <li id="recent-comments-2" class="widget-container widget_recent_comments">
+          <h3 class="widget-title">Recent Comments</h3>
+          <ul id="recentcomments">
 
-      {% assign sorted-comments = (site.data.comments.sessions | sort: '_id' | reverse) %}
+          {% assign sorted-comments = (site.data.comments.sessions | sort: '_id' | reverse) %}
 
-      {% for comment in sorted-comments limit:5 %}
-        {% assign blog-title = "" %}
-        {% for post in site.posts %}
-          {% if comment.path == post.url %}
-            {% assign blog-title = post.title %}
-          {% endif %}
-        {% endfor %}
+          {% for comment in sorted-comments limit:5 %}
+            {% assign blog-title = "" %}
+            {% for post in site.posts %}
+              {% if comment.path == post.url %}
+                {% assign blog-title = post.title %}
+              {% endif %}
+            {% endfor %}
 
-        {% if blog-title == "" %}
-          {% assign blog-title = "" %}
-          {% for page in site.pages %}
-            {% if comment.path == page.url %}
-              {% assign blog-title = page.breadcrumb %}
+            {% if blog-title == "" %}
+              {% assign blog-title = "" %}
+              {% for page in site.pages %}
+                {% if comment.path == page.url %}
+                  {% assign blog-title = page.breadcrumb %}
+                {% endif %}
+              {% endfor %}
+            {% endif %}
+
+              <li class="recentcomments"><span class="comment-author-link">{{ comment.name }}</span> on <a href="{{ site.baseurl }}{{ comment.path }}#comment-{{ comment._id }}">{{blog-title}}</a></li>     
+
+            {% endfor %}
+            </ul>
+        </li>
+
+        <!-- Archives -->
+        <li id="archives-2" class="widget-container widget_archive">
+          <h3 class="widget-title">Archives</h3>
+          <ul>
+          {% for post in site.posts %}
+            {% assign thisyear = post.date | date: "%B %Y" %}
+            {% assign prevyear = post.previous.date | date: "%B %Y" %}
+            {% if thisyear != prevyear %}
+              <li><a href="{{ site.baseurl }}/{{ post.date | date: "%Y" }}/{{ post.date | date: "%m"}}/">{{ thisyear }}</a></li>
             {% endif %}
           {% endfor %}
-        {% endif %}
+          </ul>
+        </li>
 
-          <li class="recentcomments"><span class="comment-author-link">{{ comment.name }}</span> on <a href="{{ site.baseurl }}{{ comment.path }}#comment-{{ comment._id }}">{{blog-title}}</a></li>     
+        <!-- Tag Cloud -->
+        <li id="tag_cloud-3" class="widget-container widget_tag_cloud">
+          <h3 class="widget-title">Tags</h3>
+          <div class="tagcloud">
 
-        {% endfor %}
-        </ul>
-    </li>
+          {% assign sorted_tags = (site.tags | sort:0) %}
 
-    <!-- Archives -->
-    <li id="archives-2" class="widget-container widget_archive">
-      <h3 class="widget-title">Archives</h3>
-      <ul>
-      {% for post in site.posts %}
-        {% assign thisyear = post.date | date: "%B %Y" %}
-        {% assign prevyear = post.previous.date | date: "%B %Y" %}
-        {% if thisyear != prevyear %}
-          <li><a href="{{ site.baseurl }}/{{ post.date | date: "%Y" }}/{{ post.date | date: "%m"}}/">{{ thisyear }}</a></li>
-        {% endif %}
-      {% endfor %}
+          {% for tag in sorted_tags %}
+            <a href="{{ site.baseurl }}/tag/{{ tag | first | slugize | replace: ' ', '-' }}/" title="{{ tag[1].size }} topics" style="font-size: {{ tag | last | size | times: 90 | divided_by: site.tags.size | plus: 7 }}pt">{{ tag | first }}</a>
+          {% endfor %}
+
+          </div>
+        </li>
+
+        <li id="linkcat-6" class="widget-container widget_links">
+          <h3 class="widget-title">Blogs I Like</h3>
+          <ul class="xoxo blogroll">
+            <li><a href="http://historyoftheletter.wordpress.com/">History of the Letter</a></li>
+            <li><a href="http://isitgross.com/" rel="friend" target="_blank">Is it Gross?</a></li>
+            <li><a href="http://www.jeetorious.com" title="Life through poker">Jeetorious</a></li>
+            <li><a href="http://moonside.wordpress.com/" rel="friend" target="_blank">Moonwel ot Cosideme</a></li>
+          </ul>
+        </li>
+        <li id="linkcat-70" class="widget-container widget_links">
+          <h3 class="widget-title">My Software Projects</h3>
+          <ul class="xoxo blogroll">
+            <li><a href="http://allyourtexts.com" rel="me" title="An iPhone utility I wrote" target="_blank">AllYourTexts</a></li>
+          </ul>
+        </li>
       </ul>
-    </li>
-
-    <!-- Tag Cloud -->
-    <li id="tag_cloud-3" class="widget-container widget_tag_cloud">
-      <h3 class="widget-title">Tags</h3>
-      <div class="tagcloud">
-
-      {% assign sorted_tags = (site.tags | sort:0) %}
-
-      {% for tag in sorted_tags %}
-        <a href="{{ site.baseurl }}/tag/{{ tag | first | slugize | replace: ' ', '-' }}/" title="{{ tag[1].size }} topics" style="font-size: {{ tag | last | size | times: 90 | divided_by: site.tags.size | plus: 7 }}pt">{{ tag | first }}</a>
-      {% endfor %}
-
-      </div>
-    </li>
-
-    <li id="linkcat-6" class="widget-container widget_links">
-      <h3 class="widget-title">Blogs I Like</h3>
-      <ul class="xoxo blogroll">
-        <li><a href="http://historyoftheletter.wordpress.com/">History of the Letter</a></li>
-        <li><a href="http://isitgross.com/" rel="friend" target="_blank">Is it Gross?</a></li>
-        <li><a href="http://www.jeetorious.com" title="Life through poker">Jeetorious</a></li>
-        <li><a href="http://moonside.wordpress.com/" rel="friend" target="_blank">Moonwel ot Cosideme</a></li>
-      </ul>
-    </li>
-    <li id="linkcat-70" class="widget-container widget_links">
-      <h3 class="widget-title">My Software Projects</h3>
-      <ul class="xoxo blogroll">
-        <li><a href="http://allyourtexts.com" rel="me" title="An iPhone utility I wrote" target="_blank">AllYourTexts</a></li>
-      </ul>
-    </li>
-  </ul>
-</div>
-
-
-
-
+    </div>
+    {% endunless %}
 
   </div><!-- #main -->
 

--- a/_layouts/subpage.html
+++ b/_layouts/subpage.html
@@ -11,5 +11,7 @@ layout: default
 
 {% assign post = page %}
 
-{% comment %}<!-- List comments for Blog -->{% endcomment %}
-{% include comments.html %}
+{% unless page.audience == "404" %}
+	{% comment %}<!-- List comments for Blog -->{% endcomment %}
+	{% include comments.html %}
+{% endunless %}

--- a/_pages/01-about.md
+++ b/_pages/01-about.md
@@ -1,7 +1,9 @@
 ---
-layout: about
+layout: subpage
 breadcrumb: About
 permalink: /about/
+audience: about
+title: About
 ---
 
 I’m Mike. I’m going to be in South America for a while in 2011. I’ll post the highlights here.

--- a/_pages/404.md
+++ b/_pages/404.md
@@ -1,0 +1,10 @@
+---
+layout: subpage
+breadcrumb: Not Found
+permalink: /404.html
+title: Page Not Found
+audience: "404"
+---
+
+Apologies, but the page you requested could not be found.
+

--- a/index.html
+++ b/index.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+audience: homepage
 ---
 
 {% for post in paginator.posts %}


### PR DESCRIPTION
The main objective of this pull request is to convert the 404 page over from the current site to Jekyll.  This pull request completes that piece and in doing so caused a couple other minor changes below:
- [x] Since the 404 page and the About page share pretty much the same layout and functionality, I renamed the about page layout to "subpage" to cover both of these pages.  The only difference is the 404 page doesn't have any comments and no siderail.
- [x] Added logic to the default layout to ensure the siderail does not show up for the 404 page.
- [ ] **TODO**: After reviewing this some more, I think it might be a little cleaner to extract the siderail from the default layout and put into an include file or two.  Will review this next.
- [x] Finally, noticed a minor bug where the HTML doc title was not populating correctly on the homepage or blog pagination pages.  Added logic to the default layout as well as updated the homepage with the correct audience metadata.  Looks much better with this PR and tested all other page titles as well.
