### PR TITLE
Bug - Non-Ascii Text removed from Blog Pagination

### DIFF
--- a/_includes/blog-header.html
+++ b/_includes/blog-header.html
@@ -7,7 +7,7 @@ Logic that makes the authre "Mike" = admin
 	{% assign author-url = post.author %}
 {% endif %}
 
-  <h2 class="entry-title"><a href="{{site.baseurl}}{{ post.url }}" rel="bookmark">{{ post.breadcrumb }}</a></h2>
+  <h2 class="entry-title"><a href="{{site.baseurl}}{{ post.url }}" rel="bookmark">{{ post.title }}</a></h2>
 
   <div class="entry-meta">
     <span class="meta-prep meta-prep-author">Posted on</span>

--- a/_includes/comments.html
+++ b/_includes/comments.html
@@ -3,7 +3,7 @@
 
 {% if comment-counter > 0 %}
 <div id="comments">
-  <h3 id="comments-title">{{comment-counter}} Response{% if comment-counter > 1%}s{% endif %} to <em>{{page.breadcrumb}}</em></h3>
+  <h3 id="comments-title">{{comment-counter}} Response{% if comment-counter > 1%}s{% endif %} to <em>{{page.title}}</em></h3>
   <ol class="commentlist">
 
   {% for comment in site.data.comments.sessions %}

--- a/_includes/siderail.html
+++ b/_includes/siderail.html
@@ -9,7 +9,7 @@
           <h3 class="widget-title">{{ siderail.recent-posts-title }}</h3>
           <ul>
           {% for post in site.posts limit:5 %}  
-            <li><a href="{{ site.baseurl }}{{ post.url }}">{{ post.breadcrumb }}</a></li>  
+            <li><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a></li>  
           {% endfor %} 
           </ul>
         </li>
@@ -33,7 +33,7 @@
               {% assign blog-title = "" %}
               {% for page in site.pages %}
                 {% if comment.path == page.url %}
-                  {% assign blog-title = page.breadcrumb %}
+                  {% assign blog-title = page.title %}
                 {% endif %}
               {% endfor %}
             {% endif %}

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -7,7 +7,7 @@ layout: default
 
 <!-- content -->
 <div class="post type-post status-publish format-standard hentry">
-  <h1 class="entry-title">{{page.breadcrumb}}</h1>
+  <h1 class="entry-title">{{page.title}}</h1>
   <div class="entry-meta">
     <span class="meta-prep meta-prep-author">Posted on</span>
     <a href="{{site.baseurl}}{{page.url}}" title="{{ page.date | date: '%B %d, %Y' }}" rel="bookmark"><span class="entry-date">{{ page.date | date: '%B %d, %Y' }}</span></a> <span class="meta-sep">by</span>
@@ -25,7 +25,7 @@ layout: default
     {% for tag in page.tags %}
       <a href="{{ site.baseurl }}/tag/{{ tag | replace: ' ', '-' }}/" rel="tag">{{ tag }}</a>{% if forloop.last %}.{% else %},{% endif %}
     {% endfor %}
-    Bookmark the <a href="{{ site.baseurl }}{{ page.url }}" title="Permalink to {{page.breadcrumb}}" rel="bookmark">permalink</a>               
+    Bookmark the <a href="{{ site.baseurl }}{{ page.url }}" title="Permalink to {{page.title}}" rel="bookmark">permalink</a>               
   </div>
 
 </div>

--- a/_posts/2010-10-04-mikes-travel-blog-practice-edition.md
+++ b/_posts/2010-10-04-mikes-travel-blog-practice-edition.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "Mike’s Travel Blog: Practice Edition"
+title: "Mike’s Travel Blog: Practice Edition"
 author: "Mike"
 category: "travel"
 tags: []

--- a/_posts/2010-12-16-im-off.md
+++ b/_posts/2010-12-16-im-off.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "I’m Off!"
+title: "I’m Off!"
 author: "Mike"
 category: "travel"
 tags: [confusion, leaving, seattle, supplies]

--- a/_posts/2010-12-21-figuring-out-lunch-in-quito.md
+++ b/_posts/2010-12-21-figuring-out-lunch-in-quito.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "Figuring out Lunch in Quito"
+titel: "Figuring out Lunch in Quito"
 author: "Mike"
 category: "travel"
 tags: [confusion, ecuador, food, language, quito]

--- a/_posts/2010-12-21-figuring-out-lunch-in-quito.md
+++ b/_posts/2010-12-21-figuring-out-lunch-in-quito.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-titel: "Figuring out Lunch in Quito"
+title: "Figuring out Lunch in Quito"
 author: "Mike"
 category: "travel"
 tags: [confusion, ecuador, food, language, quito]

--- a/_posts/2010-12-23-baos-in-pictures.md
+++ b/_posts/2010-12-23-baos-in-pictures.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "The Quito Mall Experience"
+title: "The Quito Mall Experience"
 author: "Mike"
 category: "travel"
 tags: [banos, ecuador, pictures]

--- a/_posts/2010-12-24-the-quito-mall-experience.md
+++ b/_posts/2010-12-24-the-quito-mall-experience.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "The Quito Mall Experience"
+title: "The Quito Mall Experience"
 author: "Mike"
 category: "travel"
 tags: [culture, ecuador, food, malls, quito]

--- a/_posts/2011-01-02-new-years-in-the-galpagos.md
+++ b/_posts/2011-01-02-new-years-in-the-galpagos.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "New Year’s in the Galápagos"
+title: "New Year’s in the Galápagos"
 author: "Mike"
 category: "travel"
 tags: [ecuador, fire, galapagos, new years, traditions]

--- a/_posts/2011-01-05-learning-spanish-in-the-galpagos.md
+++ b/_posts/2011-01-05-learning-spanish-in-the-galpagos.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "Learning Spanish in the Galápagos"
+title: "Learning Spanish in the Galápagos"
 author: "Mike"
 category: "travel"
 tags: [ecuador, galapagos, spanish]

--- a/_posts/2011-01-13-teaching-argentinians-to-objectify-women.md
+++ b/_posts/2011-01-13-teaching-argentinians-to-objectify-women.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "Teaching Argentinians to Objectify Women"
+title: "Teaching Argentinians to Objectify Women"
 author: "Mike"
 category: "travel"
 tags: [girls, language, mancora, peru]

--- a/_posts/2011-01-20-getting-back-in-shape-in-lima.md
+++ b/_posts/2011-01-20-getting-back-in-shape-in-lima.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "Getting Back in Shape in Lima"
+title: "Getting Back in Shape in Lima"
 author: "Mike"
 category: "travel"
 tags: [confusion, gym, lima, peru]

--- a/_posts/2011-01-29-i-done-been-had.md
+++ b/_posts/2011-01-29-i-done-been-had.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "I done been had!"
+title: "I done been had!"
 author: "Mike"
 category: "travel"
 tags: [lima, peru, scams]

--- a/_posts/2011-01-31-im-worldly-enough-to-be-able-to-identify-exactly-two-accents.md
+++ b/_posts/2011-01-31-im-worldly-enough-to-be-able-to-identify-exactly-two-accents.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "I’m Worldly Enough to be Able to Identify Exactly Two Accents"
+title: "I’m Worldly Enough to be Able to Identify Exactly Two Accents"
 author: "Mike"
 category: "travel"
 tags: [accents, confusion, peru]

--- a/_posts/2011-02-02-anything-but-clothes-party.md
+++ b/_posts/2011-02-02-anything-but-clothes-party.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "Anything But Clothes Party"
+title: "Anything But Clothes Party"
 author: "Mike"
 category: "travel"
 tags: [costumes, lima, parties, peru]

--- a/_posts/2011-02-07-mike-tries-to-watch-a-peruvian-soap-opera.md
+++ b/_posts/2011-02-07-mike-tries-to-watch-a-peruvian-soap-opera.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "Mike Tries to Watch a Peruvian Soap Opera"
+title: "Mike Tries to Watch a Peruvian Soap Opera"
 author: "Mike"
 category: "travel"
 tags: [al fondo hay sitio, lima, peru, telenovelas, tv]

--- a/_posts/2011-02-09-my-spanish-workbook-is-trying-to-make-me-feel-stupid.md
+++ b/_posts/2011-02-09-my-spanish-workbook-is-trying-to-make-me-feel-stupid.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "My Spanish Workbook is Trying to Make Me Feel Stupid"
+title: "My Spanish Workbook is Trying to Make Me Feel Stupid"
 author: "Mike"
 category: "travel"
 tags: [spanish]

--- a/_posts/2011-02-15-cusco-kind-of-sucks.md
+++ b/_posts/2011-02-15-cusco-kind-of-sucks.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "Cusco Kind of Sucks"
+title: "Cusco Kind of Sucks"
 author: "Mike"
 category: "travel"
 tags: [cusco, peru, whining]

--- a/_posts/2011-02-16-i-ate-a-guinea-pig.md
+++ b/_posts/2011-02-16-i-ate-a-guinea-pig.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "I Ate a Guinea Pig"
+title: "I Ate a Guinea Pig"
 author: "Mike"
 category: "travel"
 tags: [cusco, food, peru]

--- a/_posts/2011-02-19-machu-picchures.md
+++ b/_posts/2011-02-19-machu-picchures.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "Machu Picchures"
+title: "Machu Picchures"
 author: "Mike"
 category: "travel"
 tags: [cusco, machu picchu, peru, pictures]

--- a/_posts/2011-02-22-moray-the-weird-peruvian-circular-trenches-thing.md
+++ b/_posts/2011-02-22-moray-the-weird-peruvian-circular-trenches-thing.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "Moray: The Weird Peruvian Circular Trenches Thing"
+title: "Moray: The Weird Peruvian Circular Trenches Thing"
 author: "Mike"
 category: "travel"
 tags: [arequipa, confusion, peru, spanish]

--- a/_posts/2011-02-26-learning-spanish-in-arequipa.md
+++ b/_posts/2011-02-26-learning-spanish-in-arequipa.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "Learning Spanish in Arequipa"
+title: "Learning Spanish in Arequipa"
 author: "Mike"
 category: "travel"
 tags: [arequipa, confusion, peru, spanish]

--- a/_posts/2011-03-02-this-road-must-be-really-hard-to-drive-on.md
+++ b/_posts/2011-03-02-this-road-must-be-really-hard-to-drive-on.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "This road must be really hard to drive on!"
+title: "This road must be really hard to drive on!"
 author: "Mike"
 category: "travel"
 tags: [arequipa, peru, pictures]

--- a/_posts/2011-03-12-lake-titicaca.md
+++ b/_posts/2011-03-12-lake-titicaca.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "Lake Titicaca"
+title: "Lake Titicaca"
 author: "Mike"
 category: "travel"
 tags: [lake titicaca, peru, pictures, puno]

--- a/_posts/2011-03-16-being-terrorized-by-small-children-for-carnivale.md
+++ b/_posts/2011-03-16-being-terrorized-by-small-children-for-carnivale.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "Being Terrorized by Small Children for Carnivale"
+title: "Being Terrorized by Small Children for Carnivale"
 author: "Mike"
 category: "travel"
 tags: [arequipa, festivals, peru, puno]

--- a/_posts/2011-03-17-the-3-month-mark.md
+++ b/_posts/2011-03-17-the-3-month-mark.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "The 3 Month Mark"
+title: "The 3 Month Mark"
 author: "Mike"
 category: "travel"
 tags: [checkpoints]

--- a/_posts/2011-03-25-argentina-is-not-part-of-south-america.md
+++ b/_posts/2011-03-25-argentina-is-not-part-of-south-america.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "Argentina is Not Part of South America"
+title: "Argentina is Not Part of South America"
 author: "Mike"
 category: "travel"
 tags: [apartments, argentina, buenos aires, salta]

--- a/_posts/2011-03-27-im-baffled-by-the-argentina-schedule.md
+++ b/_posts/2011-03-27-im-baffled-by-the-argentina-schedule.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "I’m Baffled by the Argentina Schedule"
+title: "I’m Baffled by the Argentina Schedule"
 author: "Mike"
 category: "travel"
 tags: [argentina, buenos aires, vacation]

--- a/_posts/2011-04-06-taking-a-week-off.md
+++ b/_posts/2011-04-06-taking-a-week-off.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "Taking a Week Off"
+title: "Taking a Week Off"
 author: "Mike"
 category: "travel"
 tags: [argentina, buenos aires, vacation]

--- a/_posts/2011-04-10-adventures-in-domesticity.md
+++ b/_posts/2011-04-10-adventures-in-domesticity.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "Adventures in Domesticity"
+title: "Adventures in Domesticity"
 author: "Mike"
 category: "travel"
 tags: [apartments, argentina, buenos aires, food]

--- a/_posts/2011-04-14-my-coming-home-fantasies.md
+++ b/_posts/2011-04-14-my-coming-home-fantasies.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "My Coming Home Fantasies"
+title: "My Coming Home Fantasies"
 author: "Mike"
 category: "travel"
 tags: [america, coming home, food, tv]

--- a/_posts/2011-04-17-night-of-argentinian-comedy.md
+++ b/_posts/2011-04-17-night-of-argentinian-comedy.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "Night of Argentinian Comedy"
+title: "Night of Argentinian Comedy"
 author: "Mike"
 category: "travel"
 tags: [argentina, buenos aires, comedy]

--- a/_posts/2011-04-29-did-i-get-domesticated-in-buenos-aires.md
+++ b/_posts/2011-04-29-did-i-get-domesticated-in-buenos-aires.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "Did I Get Domesticated in Buenos Aires?"
+title: "Did I Get Domesticated in Buenos Aires?"
 author: "Mike"
 category: "travel"
 tags: [argentina, buenos aires, culture, girls]

--- a/_posts/2011-05-02-ordering-food-is-hard.md
+++ b/_posts/2011-05-02-ordering-food-is-hard.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "Ordering Food is Hard"
+title: "Ordering Food is Hard"
 author: "Mike"
 category: "travel"
 tags: [argentina, buenos aires, confusion, food]

--- a/_posts/2011-05-03-lets-talk-movies.md
+++ b/_posts/2011-05-03-lets-talk-movies.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "Let’s Talk Movies"
+title: "Let’s Talk Movies"
 author: "Mike"
 category: "travel"
 tags: [confusion, movies]

--- a/_posts/2011-05-10-cordoba-in-pictures.md
+++ b/_posts/2011-05-10-cordoba-in-pictures.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "Cordoba in Pictures"
+title: "Cordoba in Pictures"
 author: "Mike"
 category: "travel"
 tags: [argentina, cordoba, pictures]

--- a/_posts/2011-05-14-my-favorite-juan-quotes.md
+++ b/_posts/2011-05-14-my-favorite-juan-quotes.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "My Favorite Juan Quotes"
+title: "My Favorite Juan Quotes"
 author: "Mike"
 category: "travel"
 tags: [argentina, cordoba, quotes]

--- a/_posts/2011-05-18-colombia-has-weird-stuff.md
+++ b/_posts/2011-05-18-colombia-has-weird-stuff.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "Colombia Has Weird Stuff"
+title: "Colombia Has Weird Stuff"
 author: "Mike"
 category: "travel"
 tags: [bogota, colombia]

--- a/_posts/2011-05-26-the-fancypants-colombia-apartment.md
+++ b/_posts/2011-05-26-the-fancypants-colombia-apartment.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "The Fancypants Colombia Apartment"
+title: "The Fancypants Colombia Apartment"
 author: "Mike"
 category: "travel"
 tags: [apartments, colombia, medellin, pictures]

--- a/_posts/2011-06-05-the-five-people-you-meet-in-hostels.md
+++ b/_posts/2011-06-05-the-five-people-you-meet-in-hostels.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "The Five People You Meet in Hostels"
+title: "The Five People You Meet in Hostels"
 author: "Mike"
 category: "travel"
 tags: [hostels, stereotypes]

--- a/_posts/2011-06-07-im-a-comin-home.md
+++ b/_posts/2011-06-07-im-a-comin-home.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "I'm a' Comin' Home!"
+title: "I'm a' Comin' Home!"
 author: "Mike"
 category: "travel"
 tags: [coming home]

--- a/_posts/2011-06-17-the-6-month-mark.md
+++ b/_posts/2011-06-17-the-6-month-mark.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "The 6 Month Mark"
+title: "The 6 Month Mark"
 author: "Mike"
 category: "travel"
 tags: [checkpoints]

--- a/_posts/2011-07-03-okay-im-re-afraid-of-colombia.md
+++ b/_posts/2011-07-03-okay-im-re-afraid-of-colombia.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "Okay, I’m Re-Afraid of Colombia"
+title: "Okay, I’m Re-Afraid of Colombia"
 author: "Mike"
 category: "travel"
 tags: [colombia, freaking out, medellin]

--- a/_posts/2011-07-10-colombian-girls-are-the-most-confusing-girls-to-date.md
+++ b/_posts/2011-07-10-colombian-girls-are-the-most-confusing-girls-to-date.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "Colombian Girls are the Most Confusing Girls to Date"
+title: "Colombian Girls are the Most Confusing Girls to Date"
 author: "Mike"
 category: "travel"
 tags: [colombia, confusion, girls, medellin]

--- a/_posts/2011-07-17-giving-papaya-and-qu-ms.md
+++ b/_posts/2011-07-17-giving-papaya-and-qu-ms.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "Giving Papaya and “¿Qué Más?”"
+title: "Giving Papaya and “¿Qué Más?”"
 author: "Mike"
 category: "travel"
 tags: [colombia, language, medellin]

--- a/_posts/2011-07-19-pretending-i-learned-something-hostels.md
+++ b/_posts/2011-07-19-pretending-i-learned-something-hostels.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "Pretending I Learned Something: Hostels"
+title: "Pretending I Learned Something: Hostels"
 author: "Mike"
 category: "travel"
 tags: [hostels, pretending i learned something, travel tips]

--- a/_posts/2011-07-24-parapente-paragliding-in-san-felix-colombia.md
+++ b/_posts/2011-07-24-parapente-paragliding-in-san-felix-colombia.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "Parapente (Paragliding) in San Felix, Colombia"
+title: "Parapente (Paragliding) in San Felix, Colombia"
 author: "Mike"
 category: "travel"
 tags: [colombia, medellin, paragliding, pictures]

--- a/_posts/2011-08-01-pretending-i-learned-something-backpacker-packing-list.md
+++ b/_posts/2011-08-01-pretending-i-learned-something-backpacker-packing-list.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "Pretending I Learned Something: Backpacker Packing List"
+title: "Pretending I Learned Something: Backpacker Packing List"
 author: "Mike"
 category: "travel"
 tags: [packing list, pretending i learned something, supplies, travel tips]

--- a/_posts/2011-10-07-reintegration.md
+++ b/_posts/2011-10-07-reintegration.md
@@ -1,6 +1,6 @@
 ---
 layout: blog
-breadcrumb: "Reintegration"
+title: "Reintegration"
 author: "Mike"
 category: "travel"
 tags: [america, coming home, new york]


### PR DESCRIPTION
This update corrects non-ascii text being removed from the blog pagination previous and next links.  Jekyll pagination uses a posts "title" metadata field to get the previous and next post titles.  Before this update, the code was using a "breadcrumb" metadata field instead, which the Jekyll paginator did not recognize and so it was using the filename instead as a fallback.

Therefore, I updated all the post's "breadcrumb" and converted that to "title".  In doing so, also needed to update template references that was using "breadcrumb" as well and changed it to "title".

![blog-pagination-fix](https://cloud.githubusercontent.com/assets/2396774/12706175/08c5ff26-c84d-11e5-8817-eb963588ad5b.png)
