### PR TITLE
Bug - broken image links

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 rvm:
   - 2.1
 script:
-  - bundle exec jekyll build --config _config_dev.yml
+  - bundle exec jekyll build
   - bundle exec htmlproof ./_site --only-4xx --check-html --disable-external
 # branch whitelist, only for GitHub Pages
 branches:

--- a/_config.yml
+++ b/_config.yml
@@ -9,6 +9,7 @@ include: ['_pages']
 markdown: rdiscount
 paginate: 5
 paginate_path: "page/:num"
+destination:  ./_site/MikeDownSouth
 exclude:
   - .gitignore
   - README.md

--- a/_posts/2010-10-04-mikes-travel-blog-practice-edition.md
+++ b/_posts/2010-10-04-mikes-travel-blog-practice-edition.md
@@ -12,19 +12,19 @@ As practice, I decided to accept an invitation to Redmond, Washington to meet a 
 
 I met Albert (or “Al” as he is known by the locals) at an eatery called Coho, named for a type of fish that has historically been important in the region.
 
-<a href="{{ site.basurl }}/images/2010/10/IMG_3866.jpg">
+<a href="{{ site.baseurl }}/images/2010/10/IMG_3866.jpg">
 	<img class="size-large wp-image-6 aligncenter" title="Al and Mike outside Coho" src="{{ site.baseurl }}/images/2010/10/IMG_3866-1024x768.jpg" alt="Al and Mike outside Coho" width="640" height="480">
 </a>
 
 The waiter must have been able to tell that I was from Seattle, as he immediately addressed me in English. I was impressed by how flawlessly he spoke the language with barely a hint of his native accent. I ordered a dish that Albert told me was popular with the locals. Its name literally translates to “Chicken meat that has been grilled and placed between bread chunks.”
 
-<a href="{{ site.basurl }}/images/2010/10/IMG_3867.jpg">
+<a href="{{ site.baseurl }}/images/2010/10/IMG_3867.jpg">
 	<img class="aligncenter" title="Chicken meat that has been grilled and placed between bread chunks" src="{{ site.baseurl }}/images/2010/10/IMG_3867-1024x768.jpg" alt="Redmond style food" width="640" height="480">
 </a>
 
 The meal was delicious. As we ate, Albert and I discussed his life in Redmond. Our lives are so different, yet somehow… the same. At one point he even made a passing reference to the TV show, *Seinfeld*. I guess it’s made its way out here, too. Ha! Al described to me a traditional game that is popular among men in his town known as (not sure of exact spelling, just typing out phonetically) Starkraff Tu. From what I could deduce, the game holds great cultural importance and can even determine a man’s priority in choice of a bride.
 
-<a href="{{ site.basurl }}/images/2010/10/IMG_3868.jpg">
+<a href="{{ site.baseurl }}/images/2010/10/IMG_3868.jpg">
 	<img class="aligncenter" title="Albert eats food" src="{{ site.baseurl }}/images/2010/10/IMG_3868-1024x768.jpg" alt="Albert eats food" width="640" height="480">
 </a>
 
@@ -32,7 +32,7 @@ As he spoke, I couldn’t help but marvel at Albert. Here was a person denied al
 
 I didn’t have time to convert my cash to the local currency beforehand, so I paid for the meal by credit card. When I got the receipt, I was amused to see that the waiter had used a “Seattle-style” receipt that included a space for gratuity. As seasoned travelers know, in other parts of the world, tips are not customarily given to restaurant waiters. I realized this waiter was attempting to take advantage of the cultural divide between us, but I couldn’t blame him. If the roles were reversed and a wealthy, extremely handsome traveler came into my restaurant, I can’t definitively say that I’d be able to resist the temptation to try to prey on his ignorance. I paid the bill and bid Albert a farewell, grateful to him for immersing me in his town’s humble, yet vibrant culture.
 
-<a href="{{ site.basurl }}/images/2010/10/IMG_3875.jpg">
+<a href="{{ site.baseurl }}/images/2010/10/IMG_3875.jpg">
 	<img class="alignright size-large wp-image-14" title="Coho receipt" src="{{ site.baseurl }}/images/2010/10/IMG_3875-692x1024.jpg" alt="Coho receipt" width="384" height="568" style="margin-bottom: 12px;">
 </a>
 

--- a/_posts/2010-12-16-im-off.md
+++ b/_posts/2010-12-16-im-off.md
@@ -19,7 +19,7 @@ I’ve spent the last few days doing almost nothing but selling/giving away all 
 
 Honestly, it’s kind of scary. It’s fair to say my life in Seattle was very easy, comfortable, and familiar and it’s stressful giving up all the things that made it that way. At the same time, it’s exciting to see how long I can last living owning nothing but what I carry with me. So let’s see what that is!
 
-[![IMG_4063]({{ site.baseurl }}/images/2010/12/IMG_40631_thumb.jpg)]({{ site.basurl }}/images/2010/12/IMG_40631.jpg)
+[![IMG_4063]({{ site.baseurl }}/images/2010/12/IMG_40631_thumb.jpg)]({{ site.baseurl }}/images/2010/12/IMG_40631.jpg)
 
 Boring / self-explanatory stuff excluded:
 
@@ -29,7 +29,7 @@ Boring / self-explanatory stuff excluded:
 - *South America on a Shoestring* (Lonely Planet guide) – to tell me what to do.
 - *Infinite Jest* by David Foster Wallace - a long as hell book that I’m hoping I’ll finally have time for on this trip.
 
-[![IMG_4062]({{ site.baseurl }}/images/2010/12/IMG_4062_thumb.jpg)]({{ site.basurl }}/images/2010/12/IMG_4062.jpg)
+[![IMG_4062]({{ site.baseurl }}/images/2010/12/IMG_4062_thumb.jpg)]({{ site.baseurl }}/images/2010/12/IMG_4062.jpg)
 
 - [eBags packing cubes](http://www.amazon.com/eBags-Packing-Cubes-3pc-Titanium/dp/B0013KBVHM) – These are little zippered bags that are supposed to help organize your stuff. Long term usefulness still TBD, but it was kind of handy when reorganizing my pack to be able to pull out the little cubes of stuff instead of each individual article of clothing.
 - [Speed Dial Combination Lock](http://www.masterlock.com/product_details/CombinationPadlocks_AssortedColors_Set-Your-OwnCombination_No.1500iSpeedDialCombinationPadlocks/1500iD) – This thing is pretty awesome. It’s a padlock where instead of turning a dial, you open it by entering a secret code from an NES game. The only thieves who can steal my stuff will be the ones who also remember how to get infinite lives in Super Mario.

--- a/_posts/2010-12-21-figuring-out-lunch-in-quito.md
+++ b/_posts/2010-12-21-figuring-out-lunch-in-quito.md
@@ -8,11 +8,11 @@ tags: [confusion, ecuador, food, language, quito]
 
 For my first lunch on my own in Quito, I decided to just head into Old Town and wander around until I found something that looked good and cheap. The first restaurant I came across was Menestras del Negro:
 
-[![IMG_4070]({{ site.baseurl }}/images/2010/12/IMG_4070_thumb.jpg)]({{ site.basurl }}/images/2010/12/IMG_4070.jpg)
+[![IMG_4070]({{ site.baseurl }}/images/2010/12/IMG_4070_thumb.jpg)]({{ site.baseurl }}/images/2010/12/IMG_4070.jpg)
 
 It translates to “Beans of the Black” and if you’re not sure whether this is bizarrely offensive yet, take a closer look at the logo.
 
-[![head]({{ site.baseurl }}/images/2010/12/head_thumb.jpg)]({{ site.basurl }}/images/2010/12/head.jpg)
+[![head]({{ site.baseurl }}/images/2010/12/head_thumb.jpg)]({{ site.baseurl }}/images/2010/12/head.jpg)
 
 As an added stereotyping bonus, it’s attached to a KFC. I was sufficiently weirded out so I continued on.
 

--- a/_posts/2010-12-23-baos-in-pictures.md
+++ b/_posts/2010-12-23-baos-in-pictures.md
@@ -8,38 +8,38 @@ tags: [banos, ecuador, pictures]
 
 We left Quito for a few days to hang out in Baños, which is a small town known for its hot springs and a bunch of outdoorsy stuff like biking, hiking, ziplining. Here are some pictures.
 
-[![IMG_4077]({{ site.baseurl }}/images/2010/12/IMG_4077_thumb2.jpg)]({{ site.basurl }}/images/2010/12/IMG_40772.jpg)
+[![IMG_4077]({{ site.baseurl }}/images/2010/12/IMG_4077_thumb2.jpg)]({{ site.baseurl }}/images/2010/12/IMG_40772.jpg)
 
 Arriving in town after our 3 hour bus ride and trying to find a taxi.
 
-[![IMG_4078]({{ site.baseurl }}/images/2010/12/IMG_4078_thumb2.jpg)]({{ site.basurl }}/images/2010/12/IMG_40782.jpg)
+[![IMG_4078]({{ site.baseurl }}/images/2010/12/IMG_4078_thumb2.jpg)]({{ site.baseurl }}/images/2010/12/IMG_40782.jpg)
 
 This was the view from our hotel.
 
-[![IMG_4079]({{ site.baseurl }}/images/2010/12/IMG_4079_thumb2.jpg)]({{ site.basurl }}/images/2010/12/IMG_40792.jpg)
+[![IMG_4079]({{ site.baseurl }}/images/2010/12/IMG_4079_thumb2.jpg)]({{ site.baseurl }}/images/2010/12/IMG_40792.jpg)
 
 We sprung the extra $4/night to get the room with a hammock.
 
-[![IMG_4080]({{ site.baseurl }}/images/2010/12/IMG_4080_thumb2.jpg)]({{ site.basurl }}/images/2010/12/IMG_40802.jpg)
+[![IMG_4080]({{ site.baseurl }}/images/2010/12/IMG_4080_thumb2.jpg)]({{ site.baseurl }}/images/2010/12/IMG_40802.jpg)
 
 This billboard is posted on the way to our hotel. I don’t know the translation, but it appears to be a beauty spa for dead people.
 
-[![IMG_4082]({{ site.baseurl }}/images/2010/12/IMG_4082_thumb2.jpg)]({{ site.basurl }}/images/2010/12/IMG_40822.jpg)
+[![IMG_4082]({{ site.baseurl }}/images/2010/12/IMG_4082_thumb2.jpg)]({{ site.baseurl }}/images/2010/12/IMG_40822.jpg)
 
 On our way into town.
 
-[![IMG_4084]({{ site.baseurl }}/images/2010/12/IMG_4084_thumb1.jpg)]({{ site.basurl }}/images/2010/12/IMG_40841.jpg)
+[![IMG_4084]({{ site.baseurl }}/images/2010/12/IMG_4084_thumb1.jpg)]({{ site.baseurl }}/images/2010/12/IMG_40841.jpg)
 
 I ordered Nachos at this restaurant for dinner and they came out with a bunch of stale Doritos they’d put on a plate. Rachel complained, so they brought us another tray of fresh Doritos.
 
-[![IMG_4086]({{ site.baseurl }}/images/2010/12/IMG_4086_thumb2.jpg)]({{ site.basurl }}/images/2010/12/IMG_40862.jpg)
+[![IMG_4086]({{ site.baseurl }}/images/2010/12/IMG_4086_thumb2.jpg)]({{ site.baseurl }}/images/2010/12/IMG_40862.jpg)
 
 More cool views of the mountains.
 
-[![IMG_4088]({{ site.baseurl }}/images/2010/12/IMG_4088_thumb1.jpg)]({{ site.basurl }}/images/2010/12/IMG_40881.jpg)
+[![IMG_4088]({{ site.baseurl }}/images/2010/12/IMG_4088_thumb1.jpg)]({{ site.baseurl }}/images/2010/12/IMG_40881.jpg)
 
 Doing some ziplining over the river.
 
-[![IMG_4091]({{ site.baseurl }}/images/2010/12/IMG_4091_thumb2.jpg)]({{ site.basurl }}/images/2010/12/IMG_40912.jpg)
+[![IMG_4091]({{ site.baseurl }}/images/2010/12/IMG_4091_thumb2.jpg)]({{ site.baseurl }}/images/2010/12/IMG_40912.jpg)
 
 Yeah, what now, valley? We just ziplined the crap out of you!

--- a/_posts/2010-12-24-the-quito-mall-experience.md
+++ b/_posts/2010-12-24-the-quito-mall-experience.md
@@ -10,7 +10,7 @@ My favorite part about Quicentro, the mall in Quito, is how easy it is to maim y
 
 The highlight of the ropes course for me is this series of rope bridges that are around ten feet off the ground. Note that I said *ground*. Not ten feet above a ball pit or a big foam mat, but the cold, hard tile of the arcade floor. The same floor that everyone’s walking on, so if you timed it right, your child could take out an unsuspecting arcade patron in their fall from the rope bridge.
 
-[![IMG_4102]({{ site.baseurl }}/images/2010/12/IMG_4102_thumb1.jpg)]({{ site.basurl }}/images/2010/12/IMG_41021.jpg)
+[![IMG_4102]({{ site.baseurl }}/images/2010/12/IMG_4102_thumb1.jpg)]({{ site.baseurl }}/images/2010/12/IMG_41021.jpg)
 
 As you can see in the picture, these rope bridges are HARD! Kids are expected to walk between these little arcs of rope hanging from the ceiling two feet apart and get from one platform to the next. They get to wear helmets, but that seemed to be it in the way of precautions. There’s not even a staffer monitoring the course.
 

--- a/_posts/2011-01-02-new-years-in-the-galpagos.md
+++ b/_posts/2011-01-02-new-years-in-the-galpagos.md
@@ -14,43 +14,43 @@ FIRE
 
 The week leading up to New Year’s Eve, we were seeing lots of little papier-mâché dolls around town. It turns out these are called “viejos” (literally: “olds” or “old men”) and they’re made so they can be burnt at midnight on New Year’s. By New Year’s Eve, these dolls were *everywhere*. Most of the taxis had viejos strapped to their cars. Restaurants all had a viejo for their restaurant. Even the ATMs had them:
 
-[![IMG_4129]({{ site.baseurl }}/images/2011/01/IMG_4129_thumb.jpg)]({{ site.basurl }}/images/2011/01/IMG_41291.jpg)
+[![IMG_4129]({{ site.baseurl }}/images/2011/01/IMG_4129_thumb.jpg)]({{ site.baseurl }}/images/2011/01/IMG_41291.jpg)
 
 We heard two different explanations for the viejos. The first explanation is the nice one. You make a viejo of yourself or your friends and family and burn it to get rid of all the things you don’t want to bring with you into the new year. The less cute explanation (and the much more common one we heard) is that you burn people/things you *don’t* like because you don’t want them messing up your new year with all their stupid crap again. Politicians especially are popular viejos to burn.
 
-[![IMG_4131]({{ site.baseurl }}/images/2011/01/IMG_4131_thumb.jpg)]({{ site.basurl }}/images/2011/01/IMG_4131.jpg)
+[![IMG_4131]({{ site.baseurl }}/images/2011/01/IMG_4131_thumb.jpg)]({{ site.baseurl }}/images/2011/01/IMG_4131.jpg)
 
 Depending on your interpretation, Mi Grande (the owner of this restaurant, viejo) either really likes or really dislikes Lady Gaga. A lot of the viejos were accompanied by signs. I can’t understand all the Spanish, but I think this one is explaining what the viejo is and what he did in 2010?
 
-[![IMG_4132]({{ site.baseurl }}/images/2011/01/IMG_4132_thumb.jpg)]({{ site.basurl }}/images/2011/01/IMG_4132.jpg)
+[![IMG_4132]({{ site.baseurl }}/images/2011/01/IMG_4132_thumb.jpg)]({{ site.baseurl }}/images/2011/01/IMG_4132.jpg)
 
 At midnight, it was time to burn a viejo, so we went to Fede and Toto’s house to watch them torch their viejo.
 
-[![IMG_4135]({{ site.baseurl }}/images/2011/01/IMG_4135_thumb.jpg)]({{ site.basurl }}/images/2011/01/IMG_4135.jpg)
+[![IMG_4135]({{ site.baseurl }}/images/2011/01/IMG_4135_thumb.jpg)]({{ site.baseurl }}/images/2011/01/IMG_4135.jpg)
 
 When they broke out the gasoline, I knew it was going to be good.
 
-[![IMG_4138]({{ site.baseurl }}/images/2011/01/IMG_4138_thumb.jpg)]({{ site.basurl }}/images/2011/01/IMG_4138.jpg)
+[![IMG_4138]({{ site.baseurl }}/images/2011/01/IMG_4138_thumb.jpg)]({{ site.baseurl }}/images/2011/01/IMG_4138.jpg)
 
-[![IMG_4139]({{ site.baseurl }}/images/2011/01/IMG_4139_thumb.jpg)]({{ site.basurl }}/images/2011/01/IMG_4139.jpg)
+[![IMG_4139]({{ site.baseurl }}/images/2011/01/IMG_4139_thumb.jpg)]({{ site.baseurl }}/images/2011/01/IMG_4139.jpg)
 
 Because the viejos “die” at midnight, there’s also this thing among guys where they’ll dress in drag as the “widows” of the viejos and cry and ask for money to get them through the new year because they no longer have their viejo husbands to support them. The Ecuadoreans think this is *hilarious*, not because cross dressing is especially novel (I saw a fair amount of cross-dressers in Quito), but because there’s so much machismo that guys these same guys acting like blubbering women is really funny to them.
 
-[![IMG_1738]({{ site.baseurl }}/images/2011/01/IMG_1738_thumb.jpg)]({{ site.basurl }}/images/2011/01/IMG_1738.jpg)
+[![IMG_1738]({{ site.baseurl }}/images/2011/01/IMG_1738_thumb.jpg)]({{ site.baseurl }}/images/2011/01/IMG_1738.jpg)
 
 After midnight, the plan was to go to the pier to jump off into the water. I was under the impression that this was like an island tradition, but it turned out that it’s just like a Fede and his friends thing. But that doesn’t mean it can’t have a quaint island superstition attached to it. They jump off the pier to symbolize that January 1st is the “jumping off” point of the new year and that if you had any problems in 2010, you should leave them “underwater.” Sounds real, right?
 
 I was a little nervous about the pier jumping part of the night because when Rachel told a woman in town that we were going to do it, the woman looked horrified and asked me, “¿Tú también? ¡Dios mío!” This was a woman whose 4 year old son was next to her lighting firecrackers in his hand and throwing them into a crowded street. And something we were doing was worrying her. But it turned out to be not so scary and oh so awesome.
 
-[![IMG_4149]({{ site.baseurl }}/images/2011/01/IMG_4149_thumb.jpg)]({{ site.basurl }}/images/2011/01/IMG_4149.jpg)
+[![IMG_4149]({{ site.baseurl }}/images/2011/01/IMG_4149_thumb.jpg)]({{ site.baseurl }}/images/2011/01/IMG_4149.jpg)
 
 Everyone jumped in at once, then got out and jumped in again over and over for about 40 minutes.
 
-[![IMG_4151]({{ site.baseurl }}/images/2011/01/IMG_4151_thumb.jpg)]({{ site.basurl }}/images/2011/01/IMG_4151.jpg)
+[![IMG_4151]({{ site.baseurl }}/images/2011/01/IMG_4151_thumb.jpg)]({{ site.baseurl }}/images/2011/01/IMG_4151.jpg)
 
 After we dried ourselves off, we headed to the big outdoor party back in town.
 
-[![IMG_4157]({{ site.baseurl }}/images/2011/01/IMG_4157_thumb.jpg)]({{ site.basurl }}/images/2011/01/IMG_4157.jpg)
+[![IMG_4157]({{ site.baseurl }}/images/2011/01/IMG_4157_thumb.jpg)]({{ site.baseurl }}/images/2011/01/IMG_4157.jpg)
 
 Turns out they take New Year’s pretty damn seriously. I left at 4:30 AM and not only was the party still going strong, but there were little kids like 7 years old still dancing. Yes. I got outpartied by 7 year olds. A lot of them, at that.
 

--- a/_posts/2011-01-05-learning-spanish-in-the-galpagos.md
+++ b/_posts/2011-01-05-learning-spanish-in-the-galpagos.md
@@ -10,7 +10,7 @@ The boardwalk is called the **malecón** and not the **maricón** which means �
 
 **Viruenza** means “shame,” which I already knew, so I assumed **sin viruenza** simply meant “without shame” but apparently it doesn’t, though I’m still not entirely clear on what it means. The first time I heard it, I had just turned to Pamela after she served me ceviche and said, “Que reeeeco! [Yummy!]” and Javier smiled and said quietly to me, “sin viruenza.” The next night, I said something complimentary to Lorena and she smiled and shook her head and said, “sin viruenza.” At the time I thought she was quoting Javier, but it turns out she was just saying it too. The way it was explained to me, it’s sort of like calling someone a “player.” Javier was implying that I was hitting on Pamela and then Lorena was implying that I was trying to pursue both her and Pamela simultaneously, making me a “sin viruenza.”
 
-[![IMG_4127]({{ site.baseurl }}/images/2011/01/IMG_4127_thumb.jpg)]({{ site.basurl }}/images/2011/01/IMG_4127.jpg)
+[![IMG_4127]({{ site.baseurl }}/images/2011/01/IMG_4127_thumb.jpg)]({{ site.baseurl }}/images/2011/01/IMG_4127.jpg)
 
 **Caña** is a type of liquor they sell in the Galapagos that mixes well with Sprite and was a favorite drink among our friends during nights on the maricón malecón. Caña is spelled with a’s, not o’s, however, so when I mistakenly asked Jonny if he had, “bought **coños**,” the reason everyone started giggling was because I’d just asked him whether he’d bought “vaginas.”
 

--- a/_posts/2011-01-13-teaching-argentinians-to-objectify-women.md
+++ b/_posts/2011-01-13-teaching-argentinians-to-objectify-women.md
@@ -8,7 +8,7 @@ tags: [girls, language, mancora, peru]
 
 My first stop in Peru was Máncora, which is a surfing / beach party town in the North. I’d heard about it from lots of people in my hostel in Quito and decided to check it out for myself. While there, I spent most of my time with this group of Argentinians I’d met at my hostel (seen here playing an epic game of gigantic Jenga):
 
-[![IMG_4216]({{ site.baseurl }}/images/2011/01/IMG_4216_thumb.jpg)]({{ site.basurl }}/images/2011/01/IMG_4216.jpg)
+[![IMG_4216]({{ site.baseurl }}/images/2011/01/IMG_4216_thumb.jpg)]({{ site.baseurl }}/images/2011/01/IMG_4216.jpg)
 
 On my first night in Máncora, I was having dinner with Juan on the beach and we saw a really hot girl strip down to a bikini in front of us and I turned to Juan and said, “Daaaaamn!” He looked confused so I explained, “In America, when you see a hot girl you can say to your friend, ‘Daaaamn!’” Juan beamed and was immediately on board. He looked toward the girl and said, “DAN!” I corrected, “No, no. ‘Daaaamn.’” He seemed to get it and I figured my important cultural exchange was completed.
 

--- a/_posts/2011-01-29-i-done-been-had.md
+++ b/_posts/2011-01-29-i-done-been-had.md
@@ -12,7 +12,7 @@ Apparently his passenger (a woman in her 50’s or 60’s) didn’t have bills s
 
 The astute reader has probably figured out at this point that this was no ordinary bill breaking, but in fact… a **scam**! I tried to pay for lunch later using one of the 20’s and the waitress rejected the bill as “raro” (“strange”) but she couldn’t say for sure it was counterfeit. I clung to the hope that she was just confused; the bills seemed real to me. They had watermarks when held to the light and had special shiny ink in the right places. I tried someplace else and they said the bill felt wrong and wouldn’t accept it. Back at my hostel, I showed the bills to the staff at reception (both native Peruvians) and one guy said the bills were fine, just newly printed so they felt weird. Hooray! Sadly, the girl working with him immediately burst my bubble. The bills were definitely counterfeit. On real 20’s, the little purple/orange box in the lower left-hand corner has a subtle “20” in it when you look at it at the right angle and these bills did not.
 
-[![IMG_4223]({{ site.baseurl }}/images/2011/01/IMG_4223_thumb.jpg)]({{ site.basurl }}/images/2011/01/IMG_4223.jpg)
+[![IMG_4223]({{ site.baseurl }}/images/2011/01/IMG_4223_thumb.jpg)]({{ site.baseurl }}/images/2011/01/IMG_4223.jpg)
 
 So it’s official: I got scammed. I was taken for 60 Peruvian soles (about $22). I feel kind of stupid, but not *that* stupid. As far as scams go, I think this one was fairly non-obvious. At the time, I was aware of the fact that this could be a scam, but it seemed unlikely. I thought, “This requires a 30something cabbie to be in cahoots with this 50 or 60 year old woman.” If it was just a cabbie by himself I’d have definitely said no, but the tricky old woman / young man pair bamboozled me.
 

--- a/_posts/2011-02-02-anything-but-clothes-party.md
+++ b/_posts/2011-02-02-anything-but-clothes-party.md
@@ -12,11 +12,11 @@ I didn’t have a lot to work with because I didn’t know the area around my ho
 
 The party was just starting to get going and I was in the bathroom, halfway through my single roll of saran wrap, when I realized – no, it does not become opaque. I was wearing mostly-transparent plastic shorts. As much as I like weird costumes, that’d be a bit much. I was trying to figure out a way to somehow salvage this, when I saw the answer right in front of me. Bam! Toilet paper. I mummy wrapped a bunch of toiler paper around myself, then wrapped the saran wrap over that to secure it. It worked! Except now the white color and plastic texture made it look like I was wearing a diaper. I started wrapping toilet paper down my legs to get closer to shorts, but when I finished it looked more like a big pelvic cast. Alright, better than diaper. Let’s go!
 
-[![IMG_4225]({{ site.baseurl }}/images/2011/02/IMG_4225_thumb.jpg)]({{ site.basurl }}/images/2011/02/IMG_4225.jpg)
+[![IMG_4225]({{ site.baseurl }}/images/2011/02/IMG_4225_thumb.jpg)]({{ site.baseurl }}/images/2011/02/IMG_4225.jpg)
 
 Okay, so by the time I thought to go grab my camera, gravity had taken its toll on the costume and I’d lost the legs a bit. As you can see, my prediction of lots of sheet costumes was correct, so when I showed up with my weird saran wrap thing, people were pretty into it.
 
-[![IMG_4227]({{ site.baseurl }}/images/2011/02/IMG_4227_thumb.jpg)]({{ site.basurl }}/images/2011/02/IMG_4227.jpg)
+[![IMG_4227]({{ site.baseurl }}/images/2011/02/IMG_4227_thumb.jpg)]({{ site.baseurl }}/images/2011/02/IMG_4227.jpg)
 
 Not everyone participated in the ABC theme. In fact, almost nobody else did except the 3 people pictured previously and two of the bartenders. So for most of the party, I was walking around in a bar full of ~20-30 normally dressed people while I was wearing just plastic and toilet paper.
 

--- a/_posts/2011-02-09-my-spanish-workbook-is-trying-to-make-me-feel-stupid.md
+++ b/_posts/2011-02-09-my-spanish-workbook-is-trying-to-make-me-feel-stupid.md
@@ -8,6 +8,6 @@ tags: [spanish]
 
 I was dutifully doing exercises in my Spanish workbook a few days ago when I came across this “True or False” exercise:
 
-[![IMG_4220]({{ site.baseurl }}/images/2011/02/IMG_4220_thumb.jpg)]({{ site.basurl }}/images/2011/02/IMG_4220.jpg)
+[![IMG_4220]({{ site.baseurl }}/images/2011/02/IMG_4220_thumb.jpg)]({{ site.baseurl }}/images/2011/02/IMG_4220.jpg)
 
 C’mon, Spanish workbook! It’s not like I’ve absorbed all information in the world *except* Spanish and this is the last thing I have left to learn. I don’t know where the Summer Olympics were held in ‘92 or which team won the ‘99 World Series. Or that *ET* actually *didn’t* win Best Picture (it lost to *Gandhi*, apparently). You definitely wanted me to get that one wrong, Spanish workbook.

--- a/_posts/2011-02-16-i-ate-a-guinea-pig.md
+++ b/_posts/2011-02-16-i-ate-a-guinea-pig.md
@@ -10,24 +10,24 @@ In Ecuador and Peru, you can find “cuy” [“guinea pig”] at certain restau
 
 I ate at a restaurant on my first night in Cusco that served cuy, but I wasn’t quite in the right headspace to eat a guinea pig, so I tried alpaca meat instead (wasn’t a fan). I spent today mentally preparing for a meal of guinea pig (and not achieving much else, come to think of it). By dinnertime, I was ready and I headed to a cuy-serving restaurant I’d passed by during my meanderings about town and ordered “cuy al horno” [“oven roasted guinea pig”].
 
-[![IMG_4256]({{ site.baseurl }}/images/2011/02/IMG_4256_thumb.jpg)]({{ site.basurl }}/images/2011/02/IMG_4256.jpg)
+[![IMG_4256]({{ site.baseurl }}/images/2011/02/IMG_4256_thumb.jpg)]({{ site.baseurl }}/images/2011/02/IMG_4256.jpg)
 
 As you can see, it’s served whole. It still has teeth! It’s pretty creepy to have sitting on your plate staring back at you. The waitress was really excited that I’d ordered it and insisted on taking a picture of my first bite. She instructed me to eat it in local fashion: with my bare hands.
 
-[![IMG_4257]({{ site.baseurl }}/images/2011/02/IMG_4257_thumb.jpg)]({{ site.basurl }}/images/2011/02/IMG_4257.jpg)
+[![IMG_4257]({{ site.baseurl }}/images/2011/02/IMG_4257_thumb.jpg)]({{ site.baseurl }}/images/2011/02/IMG_4257.jpg)
 
 The skin was unexpectedly tough. I thought I’d be able to just bite into it, but I really had to pull at it to tear off a chunk of meat. Once I got past the skin, the meat had the texture and consistency of chicken, but not the taste. The taste was actually very similar to hamster meat.
 
-[![IMG_4258]({{ site.baseurl }}/images/2011/02/IMG_4258_thumb.jpg)]({{ site.basurl }}/images/2011/02/IMG_4258.jpg)
+[![IMG_4258]({{ site.baseurl }}/images/2011/02/IMG_4258_thumb.jpg)]({{ site.baseurl }}/images/2011/02/IMG_4258.jpg)
 
 I gotta say, guinea pig is pretty tasty, though it is uncomfortable to slowly rip off and eat body parts from a whole animal. Especially one that’s kind of cute when it’s alive. As I was eating it, I noticed it actually looked like a rat. Really, they could have easily served me a rat and I’d have no idea but to keep from getting too gross, let’s assume it was guinea pig.
 
-[![IMG_4259]({{ site.baseurl }}/images/2011/02/IMG_4259_thumb.jpg)]({{ site.basurl }}/images/2011/02/IMG_4259.jpg)
+[![IMG_4259]({{ site.baseurl }}/images/2011/02/IMG_4259_thumb.jpg)]({{ site.baseurl }}/images/2011/02/IMG_4259.jpg)
 
 This was the final result. All in all, a very good meal, but not the kind of thing I think I’ll do again anytime soon. It tastes good, but it’s expensive (by Peruvian standards) at around $18, which is double the price of a normal dinner. Also, I promised the demon cuy ghosts that now haunt my hostel room that I’d never do it again.
 
 To make myself look less bloodthirsty, I got a picture of me eating my dessert, a banana-chocolate crêpe, which I had absolutely no qualms about eating whole.
 
-[![IMG_4261]({{ site.baseurl }}/images/2011/02/IMG_4261_thumb.jpg)]({{ site.basurl }}/images/2011/02/IMG_4261.jpg)
+[![IMG_4261]({{ site.baseurl }}/images/2011/02/IMG_4261_thumb.jpg)]({{ site.baseurl }}/images/2011/02/IMG_4261.jpg)
 
 (my apologies to okay for this post / my sins)

--- a/_posts/2011-02-19-machu-picchures.md
+++ b/_posts/2011-02-19-machu-picchures.md
@@ -8,34 +8,34 @@ tags: [cusco, machu picchu, peru, pictures]
 
 While I was in Cusco, I decided to take a day trip to Machu Picchu. It’s an ancient Incan city that was built in the 15th century and abandoned about a hundred years later. It was rediscovered in 1911 by an American guy (go America!), who kind of stole everything and gave it to Yale and Yale now refuses to give it back to Peru (go America?).
 
-[![IMG_4268]({{ site.baseurl }}/images/2011/02/IMG_4268_thumb.jpg)]({{ site.basurl }}/images/2011/02/IMG_4268.jpg)
+[![IMG_4268]({{ site.baseurl }}/images/2011/02/IMG_4268_thumb.jpg)]({{ site.baseurl }}/images/2011/02/IMG_4268.jpg)
 
 Arriving in Aguas Calientes, the city below Machu Picchu.
 
-[![IMG_4296]({{ site.baseurl }}/images/2011/02/IMG_4296_thumb1.jpg)]({{ site.basurl }}/images/2011/02/IMG_42961.jpg)
+[![IMG_4296]({{ site.baseurl }}/images/2011/02/IMG_4296_thumb1.jpg)]({{ site.baseurl }}/images/2011/02/IMG_42961.jpg)
 
 They charge you to go to the bathroom at Machu Picchu, which wasn’t all that new for me, but the interesting part was that they actually give you an entrance ticket. Luckily, it wasn’t the kind of thing where they had patrols inside to verify proof of payment.
 
-[![IMG_4269]({{ site.baseurl }}/images/2011/02/IMG_4269_thumb1.jpg)]({{ site.basurl }}/images/2011/02/IMG_42691.jpg)
+[![IMG_4269]({{ site.baseurl }}/images/2011/02/IMG_4269_thumb1.jpg)]({{ site.baseurl }}/images/2011/02/IMG_42691.jpg)
 
 Arrival into Machu Picchu! It was a bit cloudy / rainy when we first got in, so you can see most of the city in this shot, but Wayna Picchu (the big mountain behind the city) is hidden by the clouds. Pro tip: a good way to make it stop raining is to go to the trouble of getting out and putting on your rain jacket.
 
-[![IMG_4272]({{ site.baseurl }}/images/2011/02/IMG_4272_thumb.jpg)]({{ site.basurl }}/images/2011/02/IMG_4272.jpg)
+[![IMG_4272]({{ site.baseurl }}/images/2011/02/IMG_4272_thumb.jpg)]({{ site.baseurl }}/images/2011/02/IMG_4272.jpg)
 
 View of the city from the other side. All of the terraces were for Incan farming back in the day. The Spaniards never found this city (which is lucky because apparently they really liked bashing the crap out of Incan cities) so 90% of the masonry is from the original construction.
 
-[![IMG_4279]({{ site.baseurl }}/images/2011/02/IMG_4279_thumb.jpg)]({{ site.basurl }}/images/2011/02/IMG_4279.jpg)
+[![IMG_4279]({{ site.baseurl }}/images/2011/02/IMG_4279_thumb.jpg)]({{ site.baseurl }}/images/2011/02/IMG_4279.jpg)
 
 I was sort of baffled the entire time how the Incas could arrived at one of these giant mountains in the middle of nowhere and thought, “Hey, let’s build an awesome city *right here*!”
 
-[![IMG_4283]({{ site.baseurl }}/images/2011/02/IMG_4283_thumb.jpg)]({{ site.basurl }}/images/2011/02/IMG_4283.jpg)
+[![IMG_4283]({{ site.baseurl }}/images/2011/02/IMG_4283_thumb.jpg)]({{ site.baseurl }}/images/2011/02/IMG_4283.jpg)
 
 At the top of the city with Katrina, a friendly (albeit suspiciously clean) fellow backpacker I met on the tour. The big mountain in the back is Wayna Picchu, which conveniently escaped cloud cover right as we reached the top.
 
-[![IMG_4295]({{ site.baseurl }}/images/2011/02/IMG_4295_thumb.jpg)]({{ site.basurl }}/images/2011/02/IMG_4295.jpg)
+[![IMG_4295]({{ site.baseurl }}/images/2011/02/IMG_4295_thumb.jpg)]({{ site.baseurl }}/images/2011/02/IMG_4295.jpg)
 
 Picture from along the trail to the Inca Bridge.
 
-[![IMG_4301]({{ site.baseurl }}/images/2011/02/IMG_4301_thumb1.jpg)]({{ site.basurl }}/images/2011/02/IMG_43011.jpg)
+[![IMG_4301]({{ site.baseurl }}/images/2011/02/IMG_4301_thumb1.jpg)]({{ site.baseurl }}/images/2011/02/IMG_43011.jpg)
 
 In bargaining with the guy who sold me my trip to Machu Picchu, he said he would take $8 off the price, but he was going to take away my bus ride down the mountain (90 min walk vs. 30 min bus ride). As I was walking, tour buses would pass me every 10 minutes and the passengers would wave and laugh at me, but *they* were the suckers! $8? Ha! It actually was a pretty fun hike down, though the next day my legs were le tired.

--- a/_posts/2011-02-22-moray-the-weird-peruvian-circular-trenches-thing.md
+++ b/_posts/2011-02-22-moray-the-weird-peruvian-circular-trenches-thing.md
@@ -8,28 +8,28 @@ tags: [arequipa, confusion, peru, spanish]
 
 Moray is one of the stranger tourist attractions I’ve seen. I constantly saw pictures of it on travel agency signs, including this one:
 
-[![IMG_4303]({{ site.baseurl }}/images/2011/02/IMG_4303_thumb.jpg)]({{ site.basurl }}/images/2011/02/IMG_43031.jpg)
+[![IMG_4303]({{ site.baseurl }}/images/2011/02/IMG_4303_thumb.jpg)]({{ site.baseurl }}/images/2011/02/IMG_43031.jpg)
 
 (It actually took me several hours to realize what “By Food” was supposed to say.)
 
 For something so heavily advertised, it was surprisingly desolate. On the 90 minute bus ride over, I was the only tourist. I asked for the Moray stop and they dropped me off in the middle of nowhere, but there were some taxi drivers hanging out at the bus stop to ferry people the 15 minutes to and from the site. Even at the site, there were only a handful of other people there, which is surprising for something so cool-looking.
 
-[![IMG_4306]({{ site.baseurl }}/images/2011/02/IMG_4306_thumb.jpg)]({{ site.basurl }}/images/2011/02/IMG_4306.jpg)
+[![IMG_4306]({{ site.baseurl }}/images/2011/02/IMG_4306_thumb.jpg)]({{ site.baseurl }}/images/2011/02/IMG_4306.jpg)
 
 This is the main series of trenches at Moray. they’re about 100 ft deep. Nobody really knows why they exist, but popular theory (according to a cabbie I talked to at least) is that they were made for experimental farming, since the difference in depth causes significant differences in wind and temperature.
 
-[![IMG_4304]({{ site.baseurl }}/images/2011/02/IMG_4304_thumb.jpg)]({{ site.basurl }}/images/2011/02/IMG_4304.jpg)
+[![IMG_4304]({{ site.baseurl }}/images/2011/02/IMG_4304_thumb.jpg)]({{ site.baseurl }}/images/2011/02/IMG_4304.jpg)
 
 This is the view without any distractingly handsome men in the shot.
 
-[![IMG_4307]({{ site.baseurl }}/images/2011/02/IMG_4307_thumb.jpg)]({{ site.basurl }}/images/2011/02/IMG_4307.jpg)
+[![IMG_4307]({{ site.baseurl }}/images/2011/02/IMG_4307_thumb.jpg)]({{ site.baseurl }}/images/2011/02/IMG_4307.jpg)
 
 This was the other, slightly shallower series of trenches. Legend has it that if you enter but are not pure of heart, you turn into a small pile of stones.
 
-[![IMG_4308]({{ site.baseurl }}/images/2011/02/IMG_4308_thumb.jpg)]({{ site.basurl }}/images/2011/02/IMG_4308.jpg)
+[![IMG_4308]({{ site.baseurl }}/images/2011/02/IMG_4308_thumb.jpg)]({{ site.baseurl }}/images/2011/02/IMG_4308.jpg)
 
 The stairs are my favorite thing about Incan architecture. Where else do you get to see these kinds of stairs outside video games? This was how you got up and down in the trenches.
 
-[![IMG_4313]({{ site.baseurl }}/images/2011/02/IMG_4313_thumb.jpg)]({{ site.basurl }}/images/2011/02/IMG_4313.jpg)
+[![IMG_4313]({{ site.baseurl }}/images/2011/02/IMG_4313_thumb.jpg)]({{ site.baseurl }}/images/2011/02/IMG_4313.jpg)
 
 These girls were doing it wrong. Anyone who ever owned a Nintendo knows the only respectable way to climb these is with feet-together hops (preferably with an accompanying sound effect).

--- a/_posts/2011-03-02-this-road-must-be-really-hard-to-drive-on.md
+++ b/_posts/2011-03-02-this-road-must-be-really-hard-to-drive-on.md
@@ -8,18 +8,18 @@ tags: [arequipa, peru, pictures]
 
 I was walking back to my hostel from the Arequipa city center and I suddenly noticed that almost every business on the street was a driving school. It seemed like more driving schools than you’d need for a city of only a million people and a LOT more driving schools than you’d need on a single 3 block stretch of road in *any* city. I broke out my camera and I turned on the “driving school count overlay” feature so I could get a full count of the number of schools.
 
-[![IMG_4316_count]({{ site.baseurl }}/images/2011/03/IMG_4316_count_thumb.jpg)]({{ site.basurl }}/images/2011/03/IMG_4316_count.jpg)
+[![IMG_4316_count]({{ site.baseurl }}/images/2011/03/IMG_4316_count_thumb.jpg)]({{ site.baseurl }}/images/2011/03/IMG_4316_count.jpg)
 
-[![IMG_4317_count]({{ site.baseurl }}/images/2011/03/IMG_4317_count_thumb.jpg)]({{ site.basurl }}/images/2011/03/IMG_4317_count.jpg)
+[![IMG_4317_count]({{ site.baseurl }}/images/2011/03/IMG_4317_count_thumb.jpg)]({{ site.baseurl }}/images/2011/03/IMG_4317_count.jpg)
 
-[![IMG_4318_count]({{ site.baseurl }}/images/2011/03/IMG_4318_count_thumb.jpg)]({{ site.basurl }}/images/2011/03/IMG_4318_count.jpg)
+[![IMG_4318_count]({{ site.baseurl }}/images/2011/03/IMG_4318_count_thumb.jpg)]({{ site.baseurl }}/images/2011/03/IMG_4318_count.jpg)
 
-[![IMG_4319_count]({{ site.baseurl }}/images/2011/03/IMG_4319_count_thumb.jpg)]({{ site.basurl }}/images/2011/03/IMG_4319_count.jpg)
+[![IMG_4319_count]({{ site.baseurl }}/images/2011/03/IMG_4319_count_thumb.jpg)]({{ site.baseurl }}/images/2011/03/IMG_4319_count.jpg)
 
-[![IMG_4323_schools]({{ site.baseurl }}/images/2011/03/IMG_4323_schools_thumb.jpg)]({{ site.basurl }}/images/2011/03/IMG_4323_schools.jpg)
+[![IMG_4323_schools]({{ site.baseurl }}/images/2011/03/IMG_4323_schools_thumb.jpg)]({{ site.baseurl }}/images/2011/03/IMG_4323_schools.jpg)
 
-[![IMG_4322_count]({{ site.baseurl }}/images/2011/03/IMG_4322_count_thumb.jpg)]({{ site.basurl }}/images/2011/03/IMG_4322_count.jpg)
+[![IMG_4322_count]({{ site.baseurl }}/images/2011/03/IMG_4322_count_thumb.jpg)]({{ site.baseurl }}/images/2011/03/IMG_4322_count.jpg)
 
-[![IMG_4324_schools]({{ site.baseurl }}/images/2011/03/IMG_4324_schools_thumb.jpg)]({{ site.basurl }}/images/2011/03/IMG_4324_schools.jpg)
+[![IMG_4324_schools]({{ site.baseurl }}/images/2011/03/IMG_4324_schools_thumb.jpg)]({{ site.baseurl }}/images/2011/03/IMG_4324_schools.jpg)
 
 Fourteen driving schools! I repeat that this is on a single 3 block stretch of road! I’ve seen this a lot in Peru. Sometimes it’s something like a bunch of candle stores or lamp stores clumped together, which makes a little more sense. Other times it’s a street with like 9 identical book stores in a row. I don’t know if there’s some sort of weird zoning laws or if one business opens and everyone else is like, “What a great business slash location! I’ll do the same.”

--- a/_posts/2011-03-12-lake-titicaca.md
+++ b/_posts/2011-03-12-lake-titicaca.md
@@ -8,9 +8,9 @@ tags: [lake titicaca, peru, pictures, puno]
 
 I took a trip to Puno, Peru to see Lake Titicaca, the world’s largest high-altitude lake (a superlative which, in itself, has the distinction of being the world’s most arbitrary superlative). I did a day tour and the first stop was the Uros. They’re these little man-made floating islands constructed of reeds. The houses are made of dried reeds. All the furniture is made of reeds. For food, they eat fish… and reeds.
 
-[![IMG_4329]({{ site.baseurl }}/images/2011/03/IMG_4329_thumb1.jpg)]({{ site.basurl }}/images/2011/03/IMG_43291.jpg)
+[![IMG_4329]({{ site.baseurl }}/images/2011/03/IMG_4329_thumb1.jpg)]({{ site.baseurl }}/images/2011/03/IMG_43291.jpg)
 
-They claimed that the Uros people lived there full time, but I’ve heard that it’s kind of a gimmick and while they at one point lived there full time because they couldn’t afford to live on land, now the whole “we really live here” is mostly a show for tourists. This is my skeptical face:[![IMG_4328]({{ site.baseurl }}/images/2011/03/IMG_4328_thumb1.jpg)]({{ site.basurl }}/images/2011/03/IMG_43281.jpg)
+They claimed that the Uros people lived there full time, but I’ve heard that it’s kind of a gimmick and while they at one point lived there full time because they couldn’t afford to live on land, now the whole “we really live here” is mostly a show for tourists. This is my skeptical face:[![IMG_4328]({{ site.baseurl }}/images/2011/03/IMG_4328_thumb1.jpg)]({{ site.baseurl }}/images/2011/03/IMG_43281.jpg)
 
 The “residents” split us into groups and took us into their houses, which curiously contained no signs of living and instead only handcrafts they were selling. One elderly woman chose me and a Japanese guy to show her house to and as we walked over she asked us our names, which seemed a friendly enough gesture. But then when she started trying to sell us stuff, she went into full on begging mode, getting on the floor, holding out her crafts and saying, “Please…. 10 soles. Please… *Michael*.” I’m used to Peruvian begging, but when they add in your name it’s really creepy. Doubly so when you’re trapped with them on a tiny island.
 
@@ -24,24 +24,24 @@ The other island we visited was Taquile. On the boat ride there, they gave us th
 
 Naturally, I envisioned this:
 
-[![smurfs]({{ site.baseurl }}/images/2011/03/smurfs_thumb.jpg)]({{ site.basurl }}/images/2011/03/smurfs.jpg)
+[![smurfs]({{ site.baseurl }}/images/2011/03/smurfs_thumb.jpg)]({{ site.baseurl }}/images/2011/03/smurfs.jpg)
 
 But it was a little more like this:
 
-[![IMG_4339]({{ site.baseurl }}/images/2011/03/IMG_4339_thumb1.jpg)]({{ site.basurl }}/images/2011/03/IMG_43391.jpg)
+[![IMG_4339]({{ site.baseurl }}/images/2011/03/IMG_4339_thumb1.jpg)]({{ site.baseurl }}/images/2011/03/IMG_43391.jpg)
 
 The hats were the best part. It’s an island where all the men who are married have solid red hats and all the men who are single have red and white hats. It sounds like the setup to a really good riddle.
 
 It was a pretty cool island. They had these weird animals they claimed were cows, but I wasn’t buying it.
 
-[![IMG_4330]({{ site.baseurl }}/images/2011/03/IMG_4330_thumb1.jpg)]({{ site.basurl }}/images/2011/03/IMG_43301.jpg)
+[![IMG_4330]({{ site.baseurl }}/images/2011/03/IMG_4330_thumb1.jpg)]({{ site.baseurl }}/images/2011/03/IMG_43301.jpg)
 
 In the afternoon, the clouds cleared and we got really good views of the lake
 
-[![IMG_4337]({{ site.baseurl }}/images/2011/03/IMG_4337_thumb1.jpg)]({{ site.basurl }}/images/2011/03/IMG_43371.jpg)
+[![IMG_4337]({{ site.baseurl }}/images/2011/03/IMG_4337_thumb1.jpg)]({{ site.baseurl }}/images/2011/03/IMG_43371.jpg)
 
-[![IMG_4338]({{ site.baseurl }}/images/2011/03/IMG_4338_thumb1.jpg)]({{ site.basurl }}/images/2011/03/IMG_43381.jpg)
+[![IMG_4338]({{ site.baseurl }}/images/2011/03/IMG_4338_thumb1.jpg)]({{ site.baseurl }}/images/2011/03/IMG_43381.jpg)
 
 It might look like I accidentally got a picture of this guy, but this was actually very deliberate because I thought he was John Waters (still not convinced it wasn’t him!).
 
-[![IMG_4333]({{ site.baseurl }}/images/2011/03/IMG_4333_thumb1.jpg)]({{ site.basurl }}/images/2011/03/IMG_43331.jpg)
+[![IMG_4333]({{ site.baseurl }}/images/2011/03/IMG_4333_thumb1.jpg)]({{ site.baseurl }}/images/2011/03/IMG_43331.jpg)

--- a/_posts/2011-03-16-being-terrorized-by-small-children-for-carnivale.md
+++ b/_posts/2011-03-16-being-terrorized-by-small-children-for-carnivale.md
@@ -12,7 +12,7 @@ A week later, I was walking back to my hostel in Puno, but found that a huge str
 
 Two hours later, I went out for drinks with these two German girls who unfortunately looked *really* foreign. As soon as we stepped out onto the street, a bunch of little kids yelled out, “Gringas!” [“white girls!”] and started chasing us with their spray cans at full blast. There were women on the corner selling cans for ~$1.50 each so we each bought one to defend ourselves and ended up in a full scale war with all the little kids at this block party.
 
-[![IMG_4341]({{ site.baseurl }}/images/2011/03/IMG_4341_thumb.jpg)]({{ site.basurl }}/images/2011/03/IMG_4341.jpg)
+[![IMG_4341]({{ site.baseurl }}/images/2011/03/IMG_4341_thumb.jpg)]({{ site.baseurl }}/images/2011/03/IMG_4341.jpg)
 
 The funny part was you’d get into these standoffs with the little kids where there are like 3 surrounding you and you’d all be pointing your spray cans at each other waiting for somebody to make the first move. You’re both covered in foam, but the little kids stand there not firing like, “Well, I don’t want to escalate this to actually *spraying* each other…” But then of course you always end up spraying each other and running off.
 

--- a/_posts/2011-03-17-the-3-month-mark.md
+++ b/_posts/2011-03-17-the-3-month-mark.md
@@ -12,7 +12,7 @@ I left the US on Dec. 16th, 2010 and arrived in Quito, Ecuador on Dec. 17th so, 
 
 I’ve spent about 30% of the money I set aside for this trip and I’ve done so in the following fashion:
 
-[![image]({{ site.baseurl }}/images/2011/03/image_thumb.png)]({{ site.basurl }}/images/2011/03/image.png)
+[![image]({{ site.baseurl }}/images/2011/03/image_thumb.png)]({{ site.baseurl }}/images/2011/03/image.png)
 
 It’s hard to project this into the next few months because it includes a lot of one-time costs at the beginning of the trip (gear, evacuation insurance, etc.), but also was in countries that are cheaper than the places I’ll be for the rest of the trip. If I had to guess I’d say my money can last me about another 6-9 months.
 

--- a/_posts/2011-03-25-argentina-is-not-part-of-south-america.md
+++ b/_posts/2011-03-25-argentina-is-not-part-of-south-america.md
@@ -10,7 +10,7 @@ tags: [apartments, argentina, buenos aires, salta]
 
 On my 24 hour bus ride from Arica, Chile to Salta, Argentina, the Canadian guy sitting next to me told me this. I thought he was kidding, but it turned out to be very true when I got to Salta. I mean, come on! This looks like Europe!
 
-[![IMG_4356]({{ site.baseurl }}/images/2011/03/IMG_4356_thumb.jpg)]({{ site.basurl }}/images/2011/03/IMG_4356.jpg)
+[![IMG_4356]({{ site.baseurl }}/images/2011/03/IMG_4356_thumb.jpg)]({{ site.baseurl }}/images/2011/03/IMG_4356.jpg)
 
 Further evidence that Argentina is actually part of Europe and not South America:
 

--- a/_posts/2011-04-06-taking-a-week-off.md
+++ b/_posts/2011-04-06-taking-a-week-off.md
@@ -12,27 +12,27 @@ I was really excited to take a vacation, which might seem strange because – we
 
 The vacation was a lot of fun and exactly what I’d hoped for. We got a fancy hotel room:
 
-[![IMG_4366]({{ site.baseurl }}/images/2011/04/IMG_4366_thumb1.jpg)]({{ site.basurl }}/images/2011/04/IMG_43661.jpg)
+[![IMG_4366]({{ site.baseurl }}/images/2011/04/IMG_4366_thumb1.jpg)]({{ site.baseurl }}/images/2011/04/IMG_43661.jpg)
 
 Fancy relative to what I’m used to at least, though I think at this point I’m pretty easily impressed by accommodations. I was overjoyed by things like having a place to leave my laptop always out and online instead of having to grab it out of a locker and wait for it to boot up every time I wanted to check my email or screw around online (and screw around online a lot I did!).
 
 The hotel claimed to have a complimentary breakfast buffet and I was pretty dubious, considering that on this trip I’ve been promised many a breakfast buffet only to have my heart broken when I realize this “buffet” is just a big basket of stale bread rolls and maybe (if I’m lucky) orange juice. This hotel turned out to have the breakfast buffet to restore my faith in breakfast buffets. Fresh fruit, croissants, fruit pastries, cheeses, ham slices, and the most amazing scrambled eggs I’ve ever had in my life.
 
-[![IMG_4368]({{ site.baseurl }}/images/2011/04/IMG_4368_thumb1.jpg)]({{ site.basurl }}/images/2011/04/IMG_43681.jpg)
+[![IMG_4368]({{ site.baseurl }}/images/2011/04/IMG_4368_thumb1.jpg)]({{ site.baseurl }}/images/2011/04/IMG_43681.jpg)
 
 Jeet was obsessed with the breakfast buffet coffee. So much so that on a night we got home at 7 AM and had breakfast buffet to end our night and were planning to crash immediately after, Jeet had two cups of coffee that kept him up 3-4 hours longer. “Still worth it, though.”
 
 Getting lots of delicious food was a big part of the vacation. Argentina has really good beef, so steak here is amazing and fairly inexpensive. Starting on day 2 of the vacation, I’ve eaten steak eight nights in a row. They’re big on dulce de leche here and I discovered during the week that bananas covered in dulce de leche is pretty much the greatest thing ever. Also, this gigantic ice cream / fruit / wafer tower thing was pretty good, but took both of us out of commission for a while after our unsuccessful attempt to finish the entire thing.
 
-[![IMG_4360]({{ site.baseurl }}/images/2011/04/IMG_4360_thumb1.jpg)]({{ site.basurl }}/images/2011/04/IMG_43601.jpg)
+[![IMG_4360]({{ site.baseurl }}/images/2011/04/IMG_4360_thumb1.jpg)]({{ site.baseurl }}/images/2011/04/IMG_43601.jpg)
 
 And since it was Spring Break, we hit the bars and clubs every night, [continuing to be mystified]({{ site.baseurl }}/2011/03/27/im-baffled-by-the-argentina-schedule/) at how Argentinians can go out as late as they do and return to work the next day. We met these two guys in Recoleta who were getting drunk with us at 2 AM and telling us about the big meeting they had to be at the next day with the head of their company at 9 AM.
 
-[![IMG_4359]({{ site.baseurl }}/images/2011/04/IMG_4359_thumb1.jpg)]({{ site.basurl }}/images/2011/04/IMG_43591.jpg)
+[![IMG_4359]({{ site.baseurl }}/images/2011/04/IMG_4359_thumb1.jpg)]({{ site.baseurl }}/images/2011/04/IMG_43591.jpg)
 
 They told me the next day that the meeting went great. I still don’t understand how they do this.
 
-[![IMG_4358]({{ site.baseurl }}/images/2011/04/IMG_4358_thumb1.jpg)]({{ site.basurl }}/images/2011/04/IMG_43581.jpg)
+[![IMG_4358]({{ site.baseurl }}/images/2011/04/IMG_4358_thumb1.jpg)]({{ site.baseurl }}/images/2011/04/IMG_43581.jpg)
 
 We also met this girl whom I felt a strong kinship with because we had matching tiny eyes that always seem closed. She also hit me with this curveball:
 
@@ -46,6 +46,6 @@ Her: Your English is too bad.
 
 I don’t have that many “going out” clothes with me and we quickly realized that one of the perils of going out in Buenos Aires is that you come home in the morning reeking of smoke. I still haven’t washed this button down yet and to go anywhere near it at this point, I have to hold my breath (which is why I’ve almost died of suffocation when I put it on to go pick up a sandwich this morning).
 
-[![IMG_4365]({{ site.baseurl }}/images/2011/04/IMG_4365_thumb1.jpg)]({{ site.basurl }}/images/2011/04/IMG_43651.jpg)
+[![IMG_4365]({{ site.baseurl }}/images/2011/04/IMG_4365_thumb1.jpg)]({{ site.baseurl }}/images/2011/04/IMG_43651.jpg)
 
 So that was Jeet Week. Now: back to the grind.

--- a/_posts/2011-04-10-adventures-in-domesticity.md
+++ b/_posts/2011-04-10-adventures-in-domesticity.md
@@ -8,31 +8,31 @@ tags: [apartments, argentina, buenos aires, food]
 
 I’ve been living in a studio apartment in Buenos Aires for the past week and I’m loving it. I’m definitely planning to find apartments from here on out in cities I stay in for more than a couple weeks in. Let me give you the tour.
 
-[![IMG_4373]({{ site.baseurl }}/images/2011/04/IMG_4373_thumb.jpg)]({{ site.basurl }}/images/2011/04/IMG_4373.jpg)
+[![IMG_4373]({{ site.baseurl }}/images/2011/04/IMG_4373_thumb.jpg)]({{ site.baseurl }}/images/2011/04/IMG_4373.jpg)
 
 This is the living room and it’s where I spend most of my time when I’m home. It’s really just so cool to have my computer in one place, always hooked up to the portable speakers and wireless mouse, always connected to the Internet (except now as I type this, my Internet has mysteriously gone out… usually I have Internet). There’s a big window so the apartment gets a lot of light, but I always keep the curtains drawn during the day otherwise the sunlight is blinding and too hot (though there is AC).
 
-[![IMG_4376]({{ site.baseurl }}/images/2011/04/IMG_4376_thumb.jpg)]({{ site.basurl }}/images/2011/04/IMG_4376.jpg)
+[![IMG_4376]({{ site.baseurl }}/images/2011/04/IMG_4376_thumb.jpg)]({{ site.baseurl }}/images/2011/04/IMG_4376.jpg)
 
 This is the bedroom (or the other half of the living room). I thought about cleaning up a little for the photo, but this is how it usually looks and I didn’t want to ruin the authenticity. Plus I’m pretty lazy about cleaning for any reason. I think I have a weekly maid, but I’m kind of confused about the particulars of that. I haven’t seen her yet.
 
-[![IMG_4374]({{ site.baseurl }}/images/2011/04/IMG_4374_thumb.jpg)]({{ site.basurl }}/images/2011/04/IMG_4374.jpg)
+[![IMG_4374]({{ site.baseurl }}/images/2011/04/IMG_4374_thumb.jpg)]({{ site.baseurl }}/images/2011/04/IMG_4374.jpg)
 
 This is my bathroom. The hot water in the shower runs from tepid to scalding, my control over which seems to be minimal.
 
-[![IMG_4377]({{ site.baseurl }}/images/2011/04/IMG_4377_thumb.jpg)]({{ site.basurl }}/images/2011/04/IMG_4377.jpg)
+[![IMG_4377]({{ site.baseurl }}/images/2011/04/IMG_4377_thumb.jpg)]({{ site.baseurl }}/images/2011/04/IMG_4377.jpg)
 
 The kitchen has unexpectedly become my favorite aspect of having an apartment. I tried cooking in hostels a few times but it was such a hassle that it wasn’t worth the trouble. It’s way better having my own kitchen. My go-to meal is steak. It’s fairly easy to cook, incredibly cheap at like $3-4 each steak, and delicious! When I lived in Seattle, it was always a bit of a challenge buying foods that would spoil fast, like fresh fruits and vegetables, but the advantage to being a bum and cooking all my own meals is that I go through groceries pretty fast, so I can buy stuff that spoils and not worry about it.
 
-[![IMG_4375]({{ site.baseurl }}/images/2011/04/IMG_4375_thumb.jpg)]({{ site.basurl }}/images/2011/04/IMG_4375.jpg)
+[![IMG_4375]({{ site.baseurl }}/images/2011/04/IMG_4375_thumb.jpg)]({{ site.baseurl }}/images/2011/04/IMG_4375.jpg)
 
 The big meal I was really excited for was oatmeal. It’s one thing I’d really missed from the US. When I said this to other backpackers, they always thought it was pretty weird because you can buy oatmeal in supermarkets and even order it in restaurants that serve breakfast. But! I make oatmeal in a *very particular way* that you can’t order in restaurants and I couldn’t make it myself in hostels because it requires a lot of ingredients that come in large quantities. Or rather I *could*, but I’d be throwing a bunch of stuff away.
 
-[![IMG_4369]({{ site.baseurl }}/images/2011/04/IMG_4369_thumb.jpg)]({{ site.basurl }}/images/2011/04/IMG_4369.jpg)
+[![IMG_4369]({{ site.baseurl }}/images/2011/04/IMG_4369_thumb.jpg)]({{ site.baseurl }}/images/2011/04/IMG_4369.jpg)
 
 I spent literally three hours shopping for the ingredients for oatmeal. Cinnamon and milk were pretty easy to find. Non-instant oatmeal was a bit tougher. Chocolate chips were *really* hard to find, but chocolate chips and/or fresh blueberries (amazing with both) are crucial to my oatmeal. Blueberries continue to elude me, which is strange because in America, the blueberries I bought were Chilean. Now I’m in Argentina and Chile’s right next door. I feel like they should just send some over. According to locals I’ve talked to, the supermarket I go to does carry them, just inconsistently and it doesn’t correspond to seasons or anything.
 
-[![IMG_4370]({{ site.baseurl }}/images/2011/04/IMG_4370_thumb.jpg)]({{ site.basurl }}/images/2011/04/IMG_4370.jpg)
+[![IMG_4370]({{ site.baseurl }}/images/2011/04/IMG_4370_thumb.jpg)]({{ site.baseurl }}/images/2011/04/IMG_4370.jpg)
 
 The first morning in my new apartment, I sat down for the breakfast I’d dreamed of. Oatmeal with chocolate chips, orange juice, and a new episode of The Daily Show (one of the few American shows I can watch online). Sadly the results were… underwhelming. The oatmeal here tastes pretty weird. It’s hard to describe how. I want to say it’s more grainy than the oatmeal in the US, but that’s like accusing it of being more oatmeal-y. It just seems more processed and bland. It was still tasty – certainly better than the complimentary breakfast (read: two pieces of bread) I got in most hostels, but not quite like oatmeal back home. It just means I have one more thing to look forward to when I return.
 

--- a/_posts/2011-04-14-my-coming-home-fantasies.md
+++ b/_posts/2011-04-14-my-coming-home-fantasies.md
@@ -9,7 +9,7 @@ tags: [america, coming home, food, tv]
 Coming home is still many months away, but I was recently talking to Al about the stuff I’m looking forward to doing when I come home. He told me that listening to me talk about my coming home fantasies made him understand how people feel when they listen to him talk about what he’s going to eat when his fasts end. So let’s start with food.
 
 <p><img src="{{ site.baseurl }}/images/2011/04/Quaker.jpg" alt="Quaker" style="display:inline;">
-	<a href="{{ site.baseurl }}/images/2011/04/GorditaCrunch.jpg" style="display: inline;"><img src="/images/2011/04/GorditaCrunch_thumb.jpg" alt="GorditaCrunch" style="display: inline;"></a>
+	<a href="{{ site.baseurl }}/images/2011/04/GorditaCrunch.jpg" style="display: inline;"><img src="{{ site.baseurl }}/images/2011/04/GorditaCrunch_thumb.jpg" alt="GorditaCrunch" style="display: inline;"></a>
 </p>
 
 I’m going to make oatmeal with old fashioned Quaker oatmeal, fresh blueberries, and Nestle chocolate chips. I’m going to get a chicken cutlet sandwich from Remi’s (in Pelham, NY). I’m going to get nachos with cheese and three cheesy gordita crunches from Taco Bell (I really hope they’re still making these; they start and stop offering this item at random).


### PR DESCRIPTION
There was a bug identified that was causing broken images on github pages hosting.  The issue was caused by a typo for a lot of the image links.  Some image links had `site.basurl` which is changed to `site.baseurl` to fix the issue identified.

Also, a good question about why the HTML proofer did not catch this issue is resolved in this PR.  Previously, HTML proofer was being executed using the local config that set the baseurl to "".  This is also why the issue was not caught locally either.  However, when putting the code up on GitHub pages, it needs a different baseurl - "/MikeDownSouth" to conform with how GitHub pages deploys the generated site.

This PR corrects the issue by modifying HTML Proofer to use the same _config file that GitHub pages uses, so it should test the generated code just like it will be in production.  Originally the problem with doing that is it was causing the HTML proofer to fail since when it was still generating and checking the files in an `_site directory`.  To get around this issue, I also had to modify the _config file so that it would generate the site in `_site/MikeDownSouth` which matches the production setup.  Should've thought of this before!
- [ ] **Minor Open Question** - Do we want to remove the _config_dev.yml file?  I think we can actually use just the _config.yml file locally now as well and it will serve from `http://localhost:4000/MikeDownSouth/` instead of just `http://localhost:4000/`.  Will leave as is for now, but its conceivable we could remove it I think.
